### PR TITLE
docs: Remove ep_­page_­view from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Etherpad is very customizable through plugins. Instructions for installing theme
 Run the following command in your Etherpad folder to get all of the features visible in the demo gif:
 
 ```
-npm install ep_headings2 ep_markdown ep_comments_page ep_align ep_page_view ep_font_color ep_webrtc ep_embedded_hyperlinks2
+npm install ep_headings2 ep_markdown ep_comments_page ep_align ep_font_color ep_webrtc ep_embedded_hyperlinks2
 ```
 
 ## Customize the style with skin variants


### PR DESCRIPTION
Removes ep_page_view plugin from the installation instructions in README.md to aid new users installing etherpad-lite.

According to the plugin directory at https://static.etherpad.org/index.html, the plugin is defunct as it is now part of etherpad-lite core and when I tried installing etherpad with the plugin (following the instructions), its installation resulted in an error every time I opened a pad.